### PR TITLE
check for TagsRegex being empty before throwing an error

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -362,10 +362,10 @@ func (ws *Workspace) Update(opts UpdateOptions) (*bool, error) {
 	// (a) tags-regex
 	// (b) trigger-patterns
 	// (c) always-trigger=true
-	if (opts.ConnectOptions != nil && opts.ConnectOptions.TagsRegex != nil) && opts.TriggerPatterns != nil {
+	if (opts.ConnectOptions != nil && (opts.ConnectOptions.TagsRegex != nil && *opts.ConnectOptions.TagsRegex != "")) && opts.TriggerPatterns != nil {
 		return nil, ErrTagsRegexAndTriggerPatterns
 	}
-	if (opts.ConnectOptions != nil && opts.ConnectOptions.TagsRegex != nil) && (opts.AlwaysTrigger != nil && *opts.AlwaysTrigger) {
+	if (opts.ConnectOptions != nil && (opts.ConnectOptions.TagsRegex != nil && *opts.ConnectOptions.TagsRegex != "")) && (opts.AlwaysTrigger != nil && *opts.AlwaysTrigger) {
 		return nil, ErrTagsRegexAndAlwaysTrigger
 	}
 	if len(opts.TriggerPatterns) > 0 && (opts.AlwaysTrigger != nil && *opts.AlwaysTrigger) {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -410,7 +410,7 @@ func (ws *Workspace) Update(opts UpdateOptions) (*bool, error) {
 			updated = true
 		} else {
 			// modify existing connection
-			if opts.TagsRegex != nil {
+			if (opts.TagsRegex != nil && *opts.ConnectOptions.TagsRegex != "") {
 				if err := ws.setTagsRegex(*opts.TagsRegex); err != nil {
 					return nil, fmt.Errorf("invalid tags-regex: %w", err)
 				}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -246,10 +246,10 @@ func NewWorkspace(opts CreateOptions) (*Workspace, error) {
 	// (a) tags-regex
 	// (b) trigger-patterns
 	// (c) always-trigger=true
-	if (opts.ConnectOptions != nil && opts.ConnectOptions.TagsRegex != nil) && opts.TriggerPatterns != nil {
+	if (opts.ConnectOptions != nil && (opts.ConnectOptions.TagsRegex != nil && *opts.ConnectOptions.TagsRegex != "")) && opts.TriggerPatterns != nil {
 		return nil, ErrTagsRegexAndTriggerPatterns
 	}
-	if (opts.ConnectOptions != nil && opts.ConnectOptions.TagsRegex != nil) && (opts.AlwaysTrigger != nil && *opts.AlwaysTrigger) {
+	if (opts.ConnectOptions != nil && (opts.ConnectOptions.TagsRegex != nil && *opts.ConnectOptions.TagsRegex != "")) && (opts.AlwaysTrigger != nil && *opts.AlwaysTrigger) {
 		return nil, ErrTagsRegexAndAlwaysTrigger
 	}
 	if len(opts.TriggerPatterns) > 0 && (opts.AlwaysTrigger != nil && *opts.AlwaysTrigger) {


### PR DESCRIPTION
This was a tweak that I had to make in order to allow workspaces with TriggerPatterns to be created via the [tfe_workspace](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace) resource from the TFE provider. It seems that this value may be coming in as an empty string if not passed, which causes this error to be thrown, and which seems to get otf a bit confused (it will attempt to repeatedly try to create the workspace, but fail, and I think it queues up further plans? I ended up having to kill off otf and start fresh if i had an apply running trying to create workspaces in this way)!